### PR TITLE
fix: prevent flash of wrong colour scheme on web load

### DIFF
--- a/app/+html.tsx
+++ b/app/+html.tsx
@@ -1,0 +1,32 @@
+import { ScrollViewStyleReset } from "expo-router/html"
+import { type PropsWithChildren } from "react"
+
+export default function Root({ children }: PropsWithChildren) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <ScrollViewStyleReset />
+      </head>
+      <body>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){
+              const m = window.matchMedia('(prefers-color-scheme: dark)');
+              const scheme = m.matches ? 'dark' : 'light';
+              window.__FREEAAC_INITIAL_SCHEME__ = scheme;
+              document.documentElement.style.colorScheme = scheme;
+              const overlay = document.createElement('div');
+              overlay.id = '__freeaac_theme_blocker__';
+              overlay.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;z-index:99999;';
+              overlay.style.backgroundColor = scheme === 'dark' ? '#141313' : '#FCF8F8';
+              document.body.appendChild(overlay);
+            })();`,
+          }}
+        />
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/components/Page/PageTitle.tsx
+++ b/components/Page/PageTitle.tsx
@@ -25,7 +25,7 @@ export default function PageTitle({
         onPress={() => setShowRenameDialog(true)}
         disabled={!editMode}
       >
-        <Text style={styles.title} numberOfLines={1}>
+        <Text style={styles.title} numberOfLines={1} ellipsizeMode="tail">
           {title}
         </Text>
       </Pressable>
@@ -49,7 +49,6 @@ const styles = StyleSheet.create({
     fontSize: FONT_SIZE.xl,
     padding: PADDING.lg,
     userSelect: "none",
-    textOverflow: "ellipsis",
   },
   titleEdit: {
     borderWidth: 1,

--- a/utils/boards.ts
+++ b/utils/boards.ts
@@ -42,6 +42,7 @@ export const generateNewPage = (
     buttons: [],
     images: [],
     sounds: [],
+    pendingMutations: [],
   }
 }
 

--- a/utils/colorScheme.ts
+++ b/utils/colorScheme.ts
@@ -1,28 +1,41 @@
 import { useEffect, useState } from "react"
 import { Platform, useColorScheme as useRNColorScheme } from "react-native"
 
+declare global {
+  interface Window {
+    __FREEAAC_INITIAL_SCHEME__?: "light" | "dark"
+  }
+}
+
 export function useColorScheme() {
   const rnColorScheme = useRNColorScheme()
   const nativeColorScheme =
     rnColorScheme === "unspecified" ? "light" : rnColorScheme
-  const [webColorScheme, setWebColorScheme] = useState<"light" | "dark">(() => {
-    if (Platform.OS === "web" && typeof window !== "undefined") {
-      return window.matchMedia("(prefers-color-scheme: dark)").matches ?
-          "dark"
-        : "light"
-    }
-    return "light"
-  })
+
+  const [webColorScheme, setWebColorScheme] = useState<"light" | "dark">("light")
 
   useEffect(() => {
-    if (Platform.OS !== "web" || typeof window === "undefined") return
-    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)")
-    const handleChange = (e: MediaQueryListEvent) => {
-      setWebColorScheme(e.matches ? "dark" : "light")
-    }
-    mediaQuery.addEventListener("change", handleChange)
-    return () => {
-      mediaQuery.removeEventListener("change", handleChange)
+    if (Platform.OS === "web" && typeof window !== "undefined") {
+      const initial =
+        window.__FREEAAC_INITIAL_SCHEME__ ??
+        (window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light")
+      setWebColorScheme(initial)
+      document.documentElement.style.colorScheme = initial
+
+      // Remove the blocker now that the correct theme is applied
+      const blocker = document.getElementById("__freeaac_theme_blocker__")
+      if (blocker) blocker.remove()
+ 
+      const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)")
+      const handleChange = (e: MediaQueryListEvent) => {
+        const next = e.matches ? "dark" : "light"
+        setWebColorScheme(next)
+        document.documentElement.style.colorScheme = next
+      }
+      mediaQuery.addEventListener("change", handleChange)
+      return () => mediaQuery.removeEventListener("change", handleChange)
     }
   }, [])
 


### PR DESCRIPTION
Fixes #91.

On web, the app was server-rendered with the light theme regardless of the user's OS preference. When the browser loaded the page in dark mode, but a brief flash of light mode occurred before React hydrated and switched to dark.

Changes:
- Add app/+html.tsx to customize the HTML document for web builds
- Inject a blocking script that detects prefers-color-scheme: dark immediately on page load, before React hydrates
- Create a full-screen overlay matching the detected scheme to cover the server-rendered light content and eliminate the flash
- Update utils/colorScheme.ts to read the pre-detected scheme after hydration, apply the correct theme, and safely remove the overlay

Also fixes two pre-existing TypeScript errors:
- Remove unsupported textOverflow CSS from PageTitle styles
- Add missing pendingMutations field to board page creation


<img width="3824" height="1884" alt="Screenshot 2026-05-30 212641" src="https://github.com/user-attachments/assets/1194dee2-d104-4e0c-bbc6-992961ca9789" />
<img width="3824" height="1870" alt="Screenshot 2026-05-30 212800" src="https://github.com/user-attachments/assets/60c5b63b-5157-43c5-87a3-48e6a30a92ed" />
