### PR TITLE
Fix/clear default board id on delete

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -31,7 +31,7 @@ export default function RootLayout() {
   const boards = useBoards()
 
   useFocusEffect(() => {
-    const boardExists = boards.find((board) => board.id === defaultBoardId)
+    const boardExists = boards.some((board) => board.id === defaultBoardId)
     if (firstLaunch && defaultBoardId && boardExists) {
       console.log("redirecting to ", defaultBoardId)
       router.push({

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -10,6 +10,7 @@ import { GestureHandlerRootView } from "react-native-gesture-handler"
 import { SafeAreaProvider } from "react-native-safe-area-context"
 import AudioController from "../components/AudioController"
 import SettingsButton from "../components/Settings/Button"
+import { useBoards } from "../stores/boards"
 import { useDefaultBoardId } from "../stores/prefs"
 import { useColorScheme } from "../utils/colorScheme"
 import { appDescription, appName } from "../utils/consts"
@@ -27,9 +28,11 @@ export default function RootLayout() {
   const router = useRouter()
   const defaultBoardId = useDefaultBoardId()
   const [firstLaunch, setFirstLaunch] = useState(true)
+  const boards = useBoards()
 
   useFocusEffect(() => {
-    if (firstLaunch && defaultBoardId) {
+    const boardExists = boards.find((board) => board.id === defaultBoardId)
+    if (firstLaunch && defaultBoardId && boardExists) {
       console.log("redirecting to ", defaultBoardId)
       router.push({
         pathname: "/[boardId]",

--- a/components/Board/BoardOptions.tsx
+++ b/components/Board/BoardOptions.tsx
@@ -49,6 +49,7 @@ export default function BoardOptions({
     if (!board) return handleError("No board found")
     await deleteBoard(board.id)
     removeBoard(board.id)
+    if (isDefaultBoard) setDefaultBoardId(undefined) // <-- adding default board id clearing to prevent redirecting to deleted board
     setShowDeleteDialog(false)
     ref.current?.dismiss()
   }

--- a/components/Board/BoardOptions.tsx
+++ b/components/Board/BoardOptions.tsx
@@ -49,7 +49,7 @@ export default function BoardOptions({
     if (!board) return handleError("No board found")
     await deleteBoard(board.id)
     removeBoard(board.id)
-    if (isDefaultBoard) setDefaultBoardId(undefined) // <-- adding default board id clearing to prevent redirecting to deleted board
+    if (isDefaultBoard) setDefaultBoardId(undefined)
     setShowDeleteDialog(false)
     ref.current?.dismiss()
   }


### PR DESCRIPTION
Fixes #106 

**Bug:** When a user deletes a board that is set as "Open on app launch", the `defaultBoardId` preference is left pointing to a non-existent board. On the next reload, the app tries to navigate to the deleted board and throws a file-not-found error, leaving the user stuck until site data is cleared.
 
**Fix:** Two-pronged approach
 
1. **[components/Board/BoardOptions.tsx](cci:7://file:///d:/PROJECTS/AAC/FreeAAC/components/Board/BoardOptions.tsx:0:0-0:0)** — Clear `defaultBoardId` when the deleted board is the current default, preventing the preference from becoming stale in the first place.
 
2. **[app/_layout.tsx](cci:7://file:///d:/PROJECTS/AAC/FreeAAC/app/_layout.tsx:0:0-0:0)** — Guard the first-launch redirect by checking `boards.find()` before calling `router.push()`. This defensively handles any remaining stale `defaultBoardId` values (e.g., from prior deletions or edge cases).
 
**Verification:**
 
1. Set a board as "Open on app launch".
2. Delete that same board via the board options menu.
3. Reload the page — the app should land on the home screen ("My boards") with no error popup.
 
---
 
**Commits:**
- fix: clear defaultBoardId when deleting the default board
- fix: guard redirect to default board if it no longer exists