### PR TITLE
Fix export on web

### DIFF
--- a/utils/file.ts
+++ b/utils/file.ts
@@ -299,8 +299,7 @@ export const deleteBoard = async (id: string) => {
 export const exportBoard = async (id: string, name: string, ext: string) => {
   const fileName = `${id}.${ext}`
   const tree = await loadBoard(id)
-  const processor = new ObfProcessor({ fileAdapter })
-  await processor.saveFromTree(tree as unknown as AACTree, fileName, false)
+  await saveBoard(fileName, tree)
   await saveFileAs(fileName, `${name}.${ext}`)
 }
 

--- a/utils/io.ts
+++ b/utils/io.ts
@@ -61,7 +61,7 @@ export const listDir = async (path: string): Promise<string[]> => {
   const root = await navigator.storage.getDirectory()
   const dir = await root.getDirectoryHandle(path)
   const dirContents = []
-  for await (const handle of Object.values(dir)) {
+  for await (const handle of dir.values()) {
     dirContents.push(handle.name)
   }
   return dirContents


### PR DESCRIPTION
This fixes a bug with the web implementation of listDir, which was causing empty exports